### PR TITLE
Uncaught SyntaxError

### DIFF
--- a/js/reader.js
+++ b/js/reader.js
@@ -292,9 +292,6 @@ async function googleSearch(query,type,start) {
     const feedContainer = document.getElementById('feed-container');
     const dateString = new Date().toISOString();
 
-    const feedContainer = document.getElementById('feed-container');
-    const dateString = new Date().toISOString();
-
         // Get generater from accounts
     // Assumes 'accounts' array has been preloaded
     // If necessary, fetch the accounts from the KVstore


### PR DESCRIPTION
Identifier 'feedContainer' has already been declared (at reader.js:295:11)